### PR TITLE
Fix garbled text for some environments

### DIFF
--- a/www/base.html
+++ b/www/base.html
@@ -2,11 +2,12 @@
 <html>
   <head>
     <title>{% block title %}{% endblock %}</title>
+    <meta charset="utf-8"> 
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, minimal-ui">
     <link rel="apple-touch-icon-precomposed" href="/trained-to-thrill/static/imgs/icon.png">
     <link rel="icon" href="/trained-to-thrill/static/imgs/icon.png">
     <meta name="apple-mobile-web-app-capable" content="yes">
-    <meta name="application-name" content="Trained To Thrill" />
+    <meta name="application-name" content="Trained To Thrill">
     <link rel="stylesheet" href="/trained-to-thrill/static/css/all.css">
     {% block head %}{% endblock %}
   </head>


### PR DESCRIPTION
The new train update thingy and the console message are garbled on my
Japanese Windows machine. Adding charset encoding should fix the issue.

Also, removed a trailing slash.
