### PR TITLE
add crossOrigin="anonymous"

### DIFF
--- a/www/static/js-unmin/views/photos.hbs
+++ b/www/static/js-unmin/views/photos.hbs
@@ -4,7 +4,7 @@
       <a href="{{flickrUrl}}">
         <span class="main-photo">
           <span class="photo-fader">
-            <img src="{{imgUrl}}" alt="" class="main-photo-img">
+            <img src="{{imgUrl}}" alt="" class="main-photo-img" crossOrigin="anonymous">
           </span>
         </span>
         <span class="title">{{title}}</span>


### PR DESCRIPTION
Flicker's server sets `access-control-allow-origin` header in the response only when the HTTP request have the `origin` header.
The server must set `vary` header for such cases. But it is not set.

So once the image was fetched without the `origin` header from the page, the responce without access-control-allow-origin header is stored in the HttpCache, and all CORS request from the ServiceWorker will fail.
http://crbug.com/409090

To avoid this problem this patch set `crossOrigin="anonymous"` to the image elements in the page.
