### PR TITLE
prepended "node " to start for those people that don't have node set up ...

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Bootstrapping projects",
   "main": "index.js",
   "scripts": {
-    "start": "./node_modules/gulp/bin/gulp.js"
+    "start": "node ./node_modules/gulp/bin/gulp.js"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
...as the default for *.js files

Hey @jakearchibald,

Loving your service worker work! (That doesn't sound like proper English.)  I'm submitting this PR because "npm start" resulted in this for me on my Windows box:

```
PS C:\GitHub\trained-to-thrill> npm start

> project-start@0.0.0 start C:\GitHub\trained-to-thrill
> ./node_modules/gulp/bin/gulp.js

'.' is not recognized as an internal or external command,
operable program or batch file.

npm ERR! project-start@0.0.0 start: `./node_modules/gulp/bin/gulp.js`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the project-start@0.0.0 start script.
npm ERR! This is most likely a problem with the project-start package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     ./node_modules/gulp/bin/gulp.js
npm ERR! You can get their info via:
npm ERR!     npm owner ls project-start
npm ERR! There is likely additional logging output above.
npm ERR! System Windows_NT 6.2.9200
npm ERR! command "C:\\Program Files\\nodejs\\\\node.exe" "C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npm-cli.js" "start"
npm ERR! cwd C:\GitHub\trained-to-thrill
npm ERR! node -v v0.10.32
npm ERR! npm -v 1.4.28
npm ERR! code ELIFECYCLE
npm ERR!
npm ERR! Additional logging details can be found in:
npm ERR!     C:\GitHub\trained-to-thrill\npm-debug.log
npm ERR! not ok code 0
```

Prepending "node " to the start command got me up and running nicely:

```
PS C:\GitHub\trained-to-thrill> npm start

> project-start@0.0.0 start C:\GitHub\trained-to-thrill
> node ./node_modules/gulp/bin/gulp.js

[09:37:46] Using gulpfile C:\GitHub\trained-to-thrill\gulpfile.js
[09:37:46] Starting 'sass'...
[09:37:47] Starting 'server'...
[09:37:47] Finished 'server' after 2.46 ms
[09:37:49] Finished 'sass' after 2.24 s
[09:37:49] Starting 'watch'...
[09:37:49] Finished 'watch' after 17 ms
[09:37:49] Starting 'default'...
[09:37:49] Finished 'default' after 12 μs
```
