### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 ## [View the Trained to Thrill demo](https://jakearchibald.github.io/trained-to-thrill/)
 
-##Instructions:
+## Instructions:
 
 1. Open Chrome
 1. Click the above link


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
